### PR TITLE
Readme Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A test for standard file system library: Simple and reasonably accurate cpp source line counter.
 
 Counts only physical source lines. No effort if made to determine logical lines of code. Empty lines, 
-comment lines (lines starting with "//"), and block comment lines (lines between "/**" and "**/") are 
+comment lines (lines starting with "//"), and block comment lines (lines between "/\*" and "*/") are 
 counted separately and reported accordingly. 
 
 ## A known issue

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A test for standard file system library: Simple and reasonably accurate cpp source line counter.
 
 Counts only physical source lines. No effort if made to determine logical lines of code. Empty lines, 
-comment lines (lines starting with "//"), and block comment lines (lines between "/*" and "*/") are 
+comment lines (lines starting with "//"), and block comment lines (lines between "/**" and "**/") are 
 counted separately and reported accordingly. 
 
 ## A known issue


### PR DESCRIPTION
Needed to escape an asterisk to avoid accidental emphasis block in markdown while trying to write C++ block comment character sequences '/' and '*'